### PR TITLE
Fix typo in StringCalculator instructions

### DIFF
--- a/katas/String Calculator.md
+++ b/katas/String Calculator.md
@@ -28,7 +28,7 @@ This kata is designed to help you learn test-first coding and refactoring. To th
 	2. Example: "2,-4,3,-5" throws "Negatives not allowed: -4,-5".
 6. Numbers greater than 1000 should be ignored.
 	1. Example: "1001,2" returns 2.
-7. Delimiters can be any length, using this syntax: "//[|||]1|||2|||3" returns 6.
+7. Delimiters can be any length, using this syntax: "//[|||]\n1|||2|||3" returns 6.
 8. Allow multiple delimiters, using this syntax: "//[|][%]\n1|2%3" returns 6.
 9. Handle multiple delimiters of any length.
 


### PR DESCRIPTION
I believe the sample input should include the new line character, because, as explained in step 4, it needs to be on a separate line.