### PR TITLE
Fix links with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@ Pull requests accepted - add your favorite kata to the catalog.
 
 A list of code kata instructions (in the /katas folder) compiled by [@ardalis](http://twitter.com/ardalis):
 
-- [Bowling Game](katas/Bowling Game.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Bowling%20Game.pdf))
-- [File Logger (mocking kata)](katas/File Logger.md)
+- [Bowling Game](katas/Bowling%20Game.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Bowling%20Game.pdf))
+- [File Logger (mocking kata)](katas/File%20Logger.md)
 - [FizzBuzz](katas/FizzBuzz.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/FizzBuzz.pdf))
-- [Gilded Rose (refactoring kata)](katas/Gilded Rose.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Gilded%20Rose.pdf))
+- [Gilded Rose (refactoring kata)](katas/Gilded%20Rose.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Gilded%20Rose.pdf))
 - [Greed](katas/Greed.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Greed.pdf))
 - [Potter](katas/Potter.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Potter.pdf))
-- [Prime Factors](katas/Prime Factors.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Prime%20Factors.pdf))
-- [Red Pencil Sale](katas/Red Pencil Sale.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Red%20Pencil%20Sale.pdf))
-- [RPG Combat](katas/RPG Combat.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/RPG%20Combat.pdf))
-- [String Calculator](katas/String Calculator.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/String%20Calculator.pdf))
-- [Tennis Scoring](katas/Tennis Scoring.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Tennis%20Scoring.pdf))
-- [Zombie Survivors](katas/Zombie Survivors.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Zombie%20Survivors.pdf))
+- [Prime Factors](katas/Prime%20Factors.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Prime%20Factors.pdf))
+- [Red Pencil Sale](katas/Red%20Pencil%20Sale.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Red%20Pencil%20Sale.pdf))
+- [RPG Combat](katas/RPG%20Combat.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/RPG%20Combat.pdf))
+- [String Calculator](<katas/String%20Calculator.md>) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/String%20Calculator.pdf))
+- [Tennis Scoring](katas/Tennis%20Scoring.md) ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Tennis%20Scoring.pdf))
+- [Zombie Survivors](katas/Zombie%20Survivors.md)  ([PDF](https://github.com/ardalis/kata-catalog/raw/master/katas/Zombie%20Survivors.pdf))
 
 # PDFs #
 


### PR DESCRIPTION
In the Github preview of the README, the links with spaces are not rendered properly